### PR TITLE
Updated alpine and phonenumbers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 
-RUN apk --update add python3
+RUN apk --update add python3 && apk add bash
 
 ENV PYTHONUNBUFFERED 1
 RUN mkdir /bag-of-holding

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@ djangorestframework==3.1.3
 django-filter==0.10.0
 django-widget-tweaks==1.4.1
 Markdown==2.6.2
-phonenumbers==7.0.8
+phonenumbers==8.5.0
 Pygments==2.0.2
 pytz==2015.4
 requests==2.7.0


### PR DESCRIPTION
Alpine no longer contains bash so I added it. Phonenumbers would no longer pull version 7 so I updated requirements to pull 8.5.0. Confirmed working on my desktop in Docker 17.06.0-ce-rc1 on mac.