### PR TITLE
Fix the reference to production.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 -r requirements/local.txt
 -r requirements/test.txt
--r requirements/production.txt
+-r requirements/prod.txt


### PR DESCRIPTION
```
pip install -r requirements.txt
Could not open requirements file: [Errno 2] No such file or directory: 'requirements/production.txt
```

`requirements.txt` reference `requirements/production.txt` but it is called  `prod.txt`. 
```
$ ls requirements
base.txt  dev.txt   local.txt prod.txt  test.txt
```